### PR TITLE
Performance improvements

### DIFF
--- a/SwipeView/SwipeView.m
+++ b/SwipeView/SwipeView.m
@@ -361,7 +361,10 @@
         UIView *itemView = [[_itemViews allValues] lastObject];
         _itemSize = itemView.frame.size;
     }
+    
+    self.itemsPerPage = _vertical ? (self.bounds.size.height / _itemSize.height) : (self.bounds.size.width / _itemSize.width);
 }
+
 - (void)updateScrollOffset
 {
     if (_wrapEnabled)
@@ -411,14 +414,14 @@
         {
             if (_vertical)
             {
-                //                frame = CGRectMake(0.0f, (self.frame.size.height - _itemSize.height * _itemsPerPage)/2.0f,
-                //                                   self.frame.size.width, _itemSize.height * _itemsPerPage);
+                frame = CGRectMake(0.0f, (self.frame.size.height - _itemSize.height * _itemsPerPage)/2.0f,
+                                   self.frame.size.width, _itemSize.height * _itemsPerPage);
                 contentSize.height = _itemSize.height * _numberOfItems;
             }
             else
             {
-                //                frame = CGRectMake((self.frame.size.width - _itemSize.width * _itemsPerPage)/2.0f,
-                //                                   0.0f, _itemSize.width * _itemsPerPage, self.frame.size.height);
+                frame = CGRectMake((self.frame.size.width - _itemSize.width * _itemsPerPage)/2.0f,
+                                   0.0f, _itemSize.width * _itemsPerPage, self.frame.size.height);
                 contentSize.width = _itemSize.width * _numberOfItems;
             }
             break;
@@ -427,12 +430,12 @@
         {
             if (_vertical)
             {
-                //                frame = CGRectMake(0.0f, 0.0f, self.frame.size.width, _itemSize.height * _itemsPerPage);
+                frame = CGRectMake(0.0f, 0.0f, self.frame.size.width, _itemSize.height * _itemsPerPage);
                 contentSize.height = _itemSize.height * _numberOfItems - (self.frame.size.height - frame.size.height);
             }
             else
             {
-                //                frame = CGRectMake(0.0f, 0.0f, _itemSize.width * _itemsPerPage, self.frame.size.height);
+                frame = CGRectMake(0.0f, 0.0f, _itemSize.width * _itemsPerPage, self.frame.size.height);
                 contentSize.width = _itemSize.width * _numberOfItems - (self.frame.size.width - frame.size.width);
             }
             break;


### PR DESCRIPTION
1. SwipeView now loads only the exact number of items visible after
   reloadData. When the current index is not at the edges, 2 more views loaded from each side.
2. reloadData does not erase the reuse pool now, instead, all the
   views are removed from screen but still inserted to the pool.
