### PR TITLE
When reloadData() is called, don't throw away queued item pool

### DIFF
--- a/SwipeView/SwipeView.m
+++ b/SwipeView/SwipeView.m
@@ -989,14 +989,15 @@
 - (void)reloadData
 {
     //remove old views
+    self.itemViewPool = [NSMutableSet set];
     for (UIView *view in self.visibleItemViews)
     {
         [view removeFromSuperview];
+        [self queueItemView:view];
     }
     
-    //reset view pools
+    //reset item views
     self.itemViews = [NSMutableDictionary dictionary];
-    self.itemViewPool = [NSMutableSet set];
     
     //get number of items
     [self updateItemSizeAndCount];


### PR DESCRIPTION
Reloading the data (a common operation for when new data is available or cell re-use) currently causes the helpful item pool to be recycled

This commit lets the item pool remain between reloads
