### PR TITLE
[Bug Fix] Fix the issue that current item index may be changed after rotation

### DIFF
--- a/SwipeView/SwipeView.m
+++ b/SwipeView/SwipeView.m
@@ -480,6 +480,14 @@
     
     if (!CGSizeEqualToSize(_scrollView.contentSize, contentSize))
     {
+        // contentSize is changed, make sure the content offset is adjusted based on the current item index
+        CGPoint newContentOffset;
+        if (_vertical) {
+          newContentOffset = CGPointMake(_scrollView.contentOffset.x, _currentItemIndex * _itemSize.height);
+        } else {
+          newContentOffset = CGPointMake(_currentItemIndex * _itemSize.width, _scrollView.contentOffset.y);
+        }
+        [self setContentOffsetWithoutEvent:newContentOffset];
         _scrollView.contentSize = contentSize;
     }
 }


### PR DESCRIPTION
This fixes the issue https://github.com/nicklockwood/SwipeView/issues/200 .

Basically when the device is rotated, the scroll view's contentSize may be changed since itemSize may be changed (by method `updateScrollViewDimensions`). However changing `contentSize` will result in `contentOffset` being changed by UIKit, then `ScrollView.scrollViewDidScroll` will be invoked and change the current item index...

This fix ensures that we update the contentOffset based on current item index when contentSize is changed.
